### PR TITLE
feat: add parseBoolean utils

### DIFF
--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -7,7 +7,7 @@
  * @func Callback function to be called after delay
  * @delay Delay for debounce in ms
  * @immediate should execute immediately
- * @returns debounced callaback function
+ * @returns debounced callback function
  */
 export const debounce = (
   func: (args: any) => void,
@@ -16,10 +16,10 @@ export const debounce = (
 ) => {
   let timeout: number | undefined | null;
 
-  return function() {
+  return function () {
     const context = null;
     const args = arguments;
-    const later = function() {
+    const later = function () {
       timeout = null;
       if (!immediate) func.apply(context, args as any);
     };

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -16,10 +16,10 @@ export const debounce = (
 ) => {
   let timeout: number | undefined | null;
 
-  return function () {
+  return function() {
     const context = null;
     const args = arguments;
-    const later = function () {
+    const later = function() {
       timeout = null;
       if (!immediate) func.apply(context, args as any);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,14 @@ import {
   getContrastingTextColor,
   trimContent,
 } from './helpers';
+
+import { parseBoolean } from './string';
+
 export {
   debounce,
   formatTime,
   formatDate,
   getContrastingTextColor,
   trimContent,
+  parseBoolean,
 };

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,0 +1,17 @@
+/**
+ * Function that parses a string boolean value and returns the corresponding boolean value
+ * @param {string | number} candidate - The string boolean value to be parsed
+ * @return {boolean} - The parsed boolean value
+ */
+
+export function parseBoolean(candidate: string | number) {
+  try {
+    // wrap in boolean to ensure that the return value
+    // is a boolean even if values like 0 or 1 are passed
+    return Boolean(
+      JSON.parse(typeof candidate === 'number' ? String(candidate) : candidate)
+    );
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/string.ts
+++ b/src/string.ts
@@ -6,11 +6,12 @@
 
 export function parseBoolean(candidate: string | number) {
   try {
+    // lowercase the string, so TRUE becomes true
+    const candidateString = String(candidate).toLowerCase();
+
     // wrap in boolean to ensure that the return value
     // is a boolean even if values like 0 or 1 are passed
-    return Boolean(
-      JSON.parse(typeof candidate === 'number' ? String(candidate) : candidate)
-    );
+    return Boolean(JSON.parse(candidateString));
   } catch (error) {
     return false;
   }

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -3,18 +3,24 @@ import { parseBoolean } from '../src';
 describe('#parseBoolean', () => {
   test('returns true for input "true"', () => {
     expect(parseBoolean('true')).toBe(true);
+    expect(parseBoolean('TRUE')).toBe(true);
+    expect(parseBoolean('True')).toBe(true);
   });
 
   test('returns false for input "false"', () => {
     expect(parseBoolean('false')).toBe(false);
+    expect(parseBoolean('FALSE')).toBe(false);
+    expect(parseBoolean('False')).toBe(false);
   });
 
   test('returns true for input "1"', () => {
     expect(parseBoolean(1)).toBe(true);
+    expect(parseBoolean('1')).toBe(true);
   });
 
   test('returns false for input "0"', () => {
     expect(parseBoolean(0)).toBe(false);
+    expect(parseBoolean('0')).toBe(false);
   });
 
   test('returns false for input "non-boolean value"', () => {

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -1,0 +1,33 @@
+import { parseBoolean } from '../src';
+
+describe('#parseBoolean', () => {
+  test('returns true for input "true"', () => {
+    expect(parseBoolean('true')).toBe(true);
+  });
+
+  test('returns false for input "false"', () => {
+    expect(parseBoolean('false')).toBe(false);
+  });
+
+  test('returns true for input "1"', () => {
+    expect(parseBoolean(1)).toBe(true);
+  });
+
+  test('returns false for input "0"', () => {
+    expect(parseBoolean(0)).toBe(false);
+  });
+
+  test('returns false for input "non-boolean value"', () => {
+    expect(parseBoolean('non-boolean value')).toBe(false);
+  });
+
+  test('returns false for input "null"', () => {
+    // @ts-ignore
+    expect(parseBoolean(null)).toBe(false);
+  });
+
+  test('returns false for input "undefined"', () => {
+    // @ts-ignore
+    expect(parseBoolean(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR adds a new function, parseBoolean, to the library. This function takes a single argument, `candidate`, which can be either a `string` or a `number`, and attempts to parse it as a boolean value. If the parsing is successful, the parsed boolean value is returned. If the parsing fails (e.g. the input is not a valid boolean string), the function returns false.

## Usage

```js
const result = parseBoolean('true'); // true
const result = parseBoolean(1); // true
const result = parseBoolean('not a boolean'); // false
```

This function can be used when you want to parse a string or number which is expected to be boolean in nature and need to ensure it returns boolean only.