### PR TITLE
feat: add math utilities for quantile computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 docs
+coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",
@@ -22,8 +22,7 @@
     "link": "npm link",
     "size": "size-limit",
     "analyze": "size-limit --why",
-    "docs": "typedoc --theme default --out docs ./src",
-    "publish": "npm publish --access public"
+    "docs": "typedoc --theme default --out docs ./src"
   },
   "peerDependencies": {},
   "prettier": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from './helpers';
 
 import { parseBoolean } from './string';
+import { sortAsc, quantile, clamp, getQuantileIntervals } from './math';
 
 export {
   debounce,
@@ -15,4 +16,8 @@ export {
   getContrastingTextColor,
   trimContent,
   parseBoolean,
+  sortAsc,
+  quantile,
+  clamp,
+  getQuantileIntervals,
 };

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,0 +1,81 @@
+/**
+ * Sorts an array of numbers in ascending order.
+ * @param {number[]} arr - The array of numbers to be sorted.
+ * @returns {number[]} - The sorted array.
+ */
+export function sortAsc(arr: number[]) {
+  // .slice() is used to create a copy of the array so that the original array is not mutated
+  return arr.slice().sort((a, b) => a - b);
+}
+
+/**
+ * Calculates the quantile value of an array at a specified percentile.
+ * @param {number[]} arr - The array of numbers to calculate the quantile value from.
+ * @param {number} q - The percentile to calculate the quantile value for.
+ * @returns {number} - The quantile value.
+ */
+export function quantile(arr: number[], q: number) {
+  const sorted = sortAsc(arr); // Sort the array in ascending order
+  return _quantileForSorted(sorted, q); // Calculate the quantile value
+}
+
+/**
+ * Clamps a value between a minimum and maximum range.
+ * @param {number} min - The minimum range.
+ * @param {number} max - The maximum range.
+ * @param {number} value - The value to be clamped.
+ * @returns {number} - The clamped value.
+ */
+export function clamp(min: number, max: number, value: number) {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+/**
+ * This method assumes the the array provided is already sorted in ascending order.
+ * It's a helper method for the quantile method and should not be exported as is.
+ *
+ * @param {number[]} arr - The array of numbers to calculate the quantile value from.
+ * @param {number} q - The percentile to calculate the quantile value for.
+ * @returns {number} - The quantile value.
+ */
+function _quantileForSorted(sorted: number[], q: number) {
+  const clamped = clamp(0, 1, q); // Clamp the percentile between 0 and 1
+  const pos = (sorted.length - 1) * clamped; // Calculate the index of the element at the specified percentile
+  const base = Math.floor(pos); // Find the index of the closest element to the specified percentile
+  const rest = pos - base; // Calculate the decimal value between the closest elements
+
+  // Interpolate the quantile value between the closest elements
+  // Most libraries don't to the interpolation, but I'm just having fun here
+  // also see https://en.wikipedia.org/wiki/Quantile#Estimating_quantiles_from_a_sample
+  if (sorted[base + 1] !== undefined) {
+    // in case the position was a integer, the rest will be 0 and the interpolation will be skipped
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+
+  // Return the closest element if there is no interpolation possible
+  return sorted[base];
+}
+
+/**
+ * Calculates the quantile values for an array of intervals.
+ * @param {number[]} data - The array of numbers to calculate the quantile values from.
+ * @param {number[]} intervals - The array of intervals to calculate the quantile values for.
+ * @returns {number[]} - The array of quantile values for the intervals.
+ */
+export const getQuantileIntervals = (data: number[], intervals: number[]) => {
+  // Sort the array in ascending order before looping through the intervals.
+  // depending on the size of the array and the number of intervals, this can speed up the process by at least twice
+  // for a random array of 100 numbers and 5 intervals, the speedup is 3x
+  // P.S. .slice() is used to create a copy of the array so that the original array is not mutated
+  const sorted = sortAsc(data.slice());
+
+  return intervals.map(interval => {
+    return _quantileForSorted(sorted, interval);
+  });
+};

--- a/src/math.ts
+++ b/src/math.ts
@@ -72,8 +72,7 @@ export const getQuantileIntervals = (data: number[], intervals: number[]) => {
   // Sort the array in ascending order before looping through the intervals.
   // depending on the size of the array and the number of intervals, this can speed up the process by at least twice
   // for a random array of 100 numbers and 5 intervals, the speedup is 3x
-  // P.S. .slice() is used to create a copy of the array so that the original array is not mutated
-  const sorted = sortAsc(data.slice());
+  const sorted = sortAsc(data);
 
   return intervals.map(interval => {
     return _quantileForSorted(sorted, interval);

--- a/test/math/clamp.test.ts
+++ b/test/math/clamp.test.ts
@@ -1,0 +1,66 @@
+import { clamp } from '../../src';
+
+describe('clamp', () => {
+  it('should return the minimum range when the value is less than the minimum range', () => {
+    const min = 0;
+    const max = 10;
+    const value = -1;
+    const expectedOutput = 0;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should return the maximum range when the value is greater than the maximum range', () => {
+    const min = 0;
+    const max = 10;
+    const value = 11;
+    const expectedOutput = 10;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should return the value when it is within the range of minimum and maximum', () => {
+    const min = 0;
+    const max = 10;
+    const value = 5;
+    const expectedOutput = 5;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should clamp negative numbers to the minimum range', () => {
+    const min = -10;
+    const max = 10;
+    const value = -20;
+    const expectedOutput = -10;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should clamp positive numbers to the maximum range', () => {
+    const min = -10;
+    const max = 10;
+    const value = 20;
+    const expectedOutput = 10;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should clamp numbers within the range to themselves', () => {
+    const min = -10;
+    const max = 10;
+    const value = 0;
+    const expectedOutput = 0;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should handle the case where the minimum and maximum values are the same', () => {
+    const min = 5;
+    const max = 5;
+    const value = 3;
+    const expectedOutput = 5;
+    const result = clamp(min, max, value);
+    expect(result).toEqual(expectedOutput);
+  });
+});

--- a/test/math/quantile.test.ts
+++ b/test/math/quantile.test.ts
@@ -1,0 +1,86 @@
+import { quantile, getQuantileIntervals } from '../../src';
+
+describe('quantile', () => {
+  it('returns the correct quantile value for an array of numbers', () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(quantile(arr, 0.25)).toBe(3.25);
+    expect(quantile(arr, 0.5)).toBe(5.5);
+    expect(quantile(arr, 0.75)).toBe(7.75);
+  });
+
+  it('returns the correct quantile value for an array of numbers with duplicates', () => {
+    const arr = [1, 2, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10];
+    expect(quantile(arr, 0.25)).toBe(2.75);
+    expect(quantile(arr, 0.5)).toBe(5.5);
+    expect(quantile(arr, 0.75)).toBe(8);
+  });
+
+  it('returns the correct quantile value for an array of numbers with even length', () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    expect(quantile(arr, 0.25)).toBe(3.75);
+    expect(quantile(arr, 0.5)).toBe(6.5);
+    expect(quantile(arr, 0.75)).toBe(9.25);
+  });
+
+  it('returns the first element for a quantile of 0', () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(quantile(arr, 0)).toBe(1);
+  });
+
+  it('returns the last element for a quantile of 1', () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(quantile(arr, 1)).toBe(10);
+  });
+
+  it('returns the correct quantile value for an array with only one element', () => {
+    const arr = [1];
+    expect(quantile(arr, 0.5)).toBe(1);
+  });
+
+  it('returns the correct quantile value for an empty array', () => {
+    const arr = [] as number[];
+    expect(quantile(arr, 0.5)).toBeUndefined();
+  });
+
+  it('clamps the percentile between 0 and 1', () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(quantile(arr, -1)).toBe(1);
+    expect(quantile(arr, 1.5)).toBe(10);
+  });
+});
+
+describe('getQuantileIntervals', () => {
+  const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  it('returns an array of quantile values for each interval', () => {
+    const intervals = [0, 0.25, 0.5, 0.75, 1];
+    const expected = [1, 3.25, 5.5, 7.75, 10];
+    expect(getQuantileIntervals(data, intervals)).toEqual(expected);
+  });
+
+  it('handles duplicate intervals', () => {
+    const intervals = [0, 0.25, 0.25, 0.5, 0.75, 0.75, 1];
+    const expected = [1, 3.25, 3.25, 5.5, 7.75, 7.75, 10];
+    expect(getQuantileIntervals(data, intervals)).toEqual(expected);
+  });
+
+  it('handles intervals that are outside the range of the data', () => {
+    const intervals = [-0.1, 0.5, 1.1];
+    const expected = [1, 5.5, 10];
+    expect(getQuantileIntervals(data, intervals)).toEqual(expected);
+  });
+
+  it('handles empty arrays', () => {
+    const intervals = [0, 0.5, 1];
+    expect(getQuantileIntervals([], intervals)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it('handles arrays with a single element', () => {
+    const intervals = [0, 0.5, 1];
+    expect(getQuantileIntervals([1], intervals)).toEqual([1, 1, 1]);
+  });
+});

--- a/test/math/sortAsc.test.ts
+++ b/test/math/sortAsc.test.ts
@@ -1,0 +1,46 @@
+import { sortAsc } from '../../src';
+
+describe('sortAsc', () => {
+  it('should return an empty array when given an empty array', () => {
+    const input = [] as number[];
+    const expectedOutput = [] as number[];
+    const result = sortAsc(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should return the same array when given an array with only one element', () => {
+    const input = [1];
+    const expectedOutput = [1];
+    const result = sortAsc(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should sort an array of positive numbers in ascending order', () => {
+    const input = [5, 1, 4, 2, 3];
+    const expectedOutput = [1, 2, 3, 4, 5];
+    const result = sortAsc(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should sort an array of negative numbers in ascending order', () => {
+    const input = [-5, -1, -4, -2, -3];
+    const expectedOutput = [-5, -4, -3, -2, -1];
+    const result = sortAsc(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should sort an array of mixed positive and negative numbers in ascending order', () => {
+    const input = [5, -1, 4, -2, 3];
+    const expectedOutput = [-2, -1, 3, 4, 5];
+    const result = sortAsc(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should not mutate the original array', () => {
+    const input = [5, 1, 4, 2, 3];
+    const expectedOutput = [1, 2, 3, 4, 5];
+    const result = sortAsc(input);
+    expect(result).toEqual(expectedOutput);
+    expect(input).toEqual([5, 1, 4, 2, 3]);
+  });
+});


### PR DESCRIPTION
This PR adds a new file called math.js to the utils library, with functions that can be used to perform mathematical operations on arrays of numbers. The file contains the following four functions:

- `sortAsc`: sort an array of numbers in ascending order. 
- `quantile`: calculate quantile values of an array for a specified percentile. 
- `clamp`: clamps a given number between a minimum and maximum range. 
- `getQuantileIntervals`: calculates the quantile values for an array of intervals.

JSDoc comments fully document all functions, including parameter descriptions and return types. This PR also includes unit tests for each function to ensure they work as expected.