### PR TITLE
fix: Provide a default to name if name is not present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",

--- a/src/canned.ts
+++ b/src/canned.ts
@@ -3,8 +3,8 @@ const MESSAGE_VARIABLES_REGEX = /{{(.*?)}}/g;
 
 const skipCodeBlocks = (str: string) => str.replace(/```(?:.|\n)+?```/g, '');
 
-export const capitalizeName = (name: string) => {
-  return name.replace(/\b(\w)/g, s => s.toUpperCase());
+export const capitalizeName = (name: string | null) => {
+  return (name || '').replace(/\b(\w)/g, s => s.toUpperCase());
 };
 
 export const getFirstName = ({ user }: { user: Sender }) => {

--- a/test/canned.test.ts
+++ b/test/canned.test.ts
@@ -167,4 +167,7 @@ describe('#capitalizeName', () => {
     const string = 'doe';
     expect(capitalizeName(string)).toBe('Doe');
   });
+  it('returns empty string if the name is null', () => {
+    expect(capitalizeName(null)).toBe('');
+  });
 });


### PR DESCRIPTION
The name accepts a null value according to our model definition. Also, we don't have a default value set. If the customer sends a null value to the contact name, it breaks the UI in the latest release.