### PR TITLE
fix: TypeError: Cannot read properties of undefined (reading 'replace')

### DIFF
--- a/src/canned.ts
+++ b/src/canned.ts
@@ -85,7 +85,7 @@ export const replaceVariablesInMessage = ({
   variables: Variables;
 }) => {
   // @ts-ignore
-  return message.replace(MESSAGE_VARIABLES_REGEX, (_, replace) => {
+  return message?.replace(MESSAGE_VARIABLES_REGEX, (_, replace) => {
     return variables[replace.trim()]
       ? variables[replace.trim().toLowerCase()]
       : '';


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-2922/typeerror-cannot-read-properties-of-undefined-reading-replace