### PR TITLE
chore: refactor method to return empty if time is null

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -112,8 +112,7 @@ export const convertSecondsToTimeUnit = (
   seconds: number,
   unitNames: { minute: string; hour: string; day: string }
 ) => {
-  if (seconds === null || seconds === 0)
-    return { time: '', unit: ''};
+  if (seconds === null || seconds === 0) return { time: '', unit: '' };
   if (seconds < 3600)
     return { time: Number((seconds / 60).toFixed(1)), unit: unitNames.minute };
   if (seconds < 86400)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -113,7 +113,7 @@ export const convertSecondsToTimeUnit = (
   unitNames: { minute: string; hour: string; day: string }
 ) => {
   if (seconds === null || seconds === 0)
-    return { time: null, unit: unitNames.minute };
+    return { time: '', unit: ''};
   if (seconds < 3600)
     return { time: Number((seconds / 60).toFixed(1)), unit: unitNames.minute };
   if (seconds < 86400)

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -46,6 +46,6 @@ describe('#convertSecondsToTimeUnit', () => {
   it("it should return { time:  '', unit: '' } if seconds passed is 0", () => {
     expect(
       convertSecondsToTimeUnit(0, { minute: 'm', hour: 'h', day: 'd' })
-    ).toEqual({ time: 1, unit: 's' });
+    ).toEqual({ time: '', unit: '' });
   });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -48,9 +48,4 @@ describe('#convertSecondsToTimeUnit', () => {
       convertSecondsToTimeUnit(0, { minute: 'm', hour: 'h', day: 'd' })
     ).toEqual({ time: 1, unit: 's' });
   });
-  it("it should return { time:  '', unit: '' } if seconds passed is null", () => {
-    expect(
-      convertSecondsToTimeUnit(null, { minute: 'm', hour: 'h', day: 'd' })
-    ).toEqual({ time: 1, unit: 's' });
-  });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -43,4 +43,14 @@ describe('#convertSecondsToTimeUnit', () => {
       })
     ).toEqual({ time: 1, unit: 'Days' });
   });
+  it("it should return { time:  '', unit: '' } if seconds passed is 0", () => {
+    expect(
+      convertSecondsToTimeUnit(0, { minute: 'm', hour: 'h', day: 'd' })
+    ).toEqual({ time: 1, unit: 's' });
+  });
+  it("it should return { time:  '', unit: '' } if seconds passed is null", () => {
+    expect(
+      convertSecondsToTimeUnit(null, { minute: 'm', hour: 'h', day: 'd' })
+    ).toEqual({ time: 1, unit: 's' });
+  });
 });


### PR DESCRIPTION
- Refactor `convertSecondsToTimeUnit` func to return `empty_string` rather than `null` if input is null