### PR TITLE
fix: download cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.32",
+  "version": "0.0.4",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.4",
+  "version": "0.0.33",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -217,9 +217,7 @@ export const downloadFile = async ({
 
   try {
     const response = await fetch(url, {
-      method: 'GET',
-      credentials: 'omit',
-      mode: 'cors',
+      cache: 'no-store',
     });
 
     if (!response.ok) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -216,9 +216,7 @@ export const downloadFile = async ({
   }
 
   try {
-    const response = await fetch(url, {
-      cache: 'no-store',
-    });
+    const response = await fetch(url, { cache: 'no-store' });
 
     if (!response.ok) {
       throw new Error(`Download failed: ${response.status}`);

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -175,9 +175,7 @@ describe('downloadFile', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith('test.com/doc.pdf', {
-        method: 'GET',
-        credentials: 'omit',
-        mode: 'cors',
+        cache: 'no-store',
       });
       expect(mockCreateObjectURL).toHaveBeenCalledWith(blob);
       expect(mockDOMElement.click).toHaveBeenCalled();


### PR DESCRIPTION
When downloading images programatically, the request can often fail with a CORS error. This happens even if the CORS headers are correctly set for the S3 bucket. 

The problem here is the browser, once the image is loaded correctly on the browser, chrome will store the response in it's cache. And when we fetch the image in the `downloadFile`  method. The cached response is served. Which, does not have the `Access-Control-Allow-Origin` header.

Multiple threads across the internet highlight this issue

1. https://serverfault.com/questions/856904/chrome-s3-cloudfront-no-access-control-allow-origin-header-on-initial-xhr-req/856948#856948
2. https://github.com/diegomura/react-pdf/issues/1283
3. https://www.hacksoft.io/blog/handle-images-cors-error-in-chrome

This PR attempts to fix this by skipping cache when raising the fetch request
