### PR TITLE
fix: Update `capitalizeName` to handle accented characters in variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",

--- a/src/canned.ts
+++ b/src/canned.ts
@@ -9,8 +9,19 @@ const MESSAGE_VARIABLES_REGEX = /{{(.*?)}}/g;
 
 const skipCodeBlocks = (str: string) => str.replace(/```(?:.|\n)+?```/g, '');
 
-export const capitalizeName = (name: string | null) => {
-  return (name || '').replace(/\b(\w)/g, s => s.toUpperCase());
+export const capitalizeName = (name: string | null): string => {
+  if (!name) return ''; // Return empty string for null or undefined input
+
+  return name
+    .split(' ') // Split the name into words based on spaces
+    .map(word => {
+      if (!word) return ''; // Handle empty strings that might result from multiple spaces
+
+      // Capitalize only the first character, leaving the rest unchanged
+      // This correctly handles accented characters like 'í' in 'Aríel'
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' '); // Rejoin the words with spaces
 };
 
 export const getFirstName = ({ user }: { user: Sender }) => {

--- a/test/canned.test.ts
+++ b/test/canned.test.ts
@@ -190,4 +190,13 @@ describe('#capitalizeName', () => {
   it('returns empty string if the name is null', () => {
     expect(capitalizeName(null)).toBe('');
   });
+  it('correctly handles names with accented characters', () => {
+    const accentedName1 = 'aríel';
+    const accentedName2 = 'josé maría';
+    const accentedName3 = 'françois';
+
+    expect(capitalizeName(accentedName1)).toBe('Aríel');
+    expect(capitalizeName(accentedName2)).toBe('José María');
+    expect(capitalizeName(accentedName3)).toBe('François');
+  });
 });


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-4068/issue-with-variables

#### **Issue:**  
Names with accented characters (e.g., "Aríel") were mis capitalized (e.g., "AríEl") in variables like `{{contact.name}}` due to a regex pattern that incorrectly treated the character after an accented letter as the start of a new word.  

#### **Solution:**  
Refactored `capitalizeName` to use a string-based approach that capitalizes only the first letter of each word while preserving the correct case of accented characters.