### PR TITLE
feat: Add a util for image zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,15 @@ import {
 import { getRecipients } from './email';
 
 import { parseBoolean } from './string';
-import { sortAsc, quantile, clamp, getQuantileIntervals } from './math';
+import {
+  sortAsc,
+  quantile,
+  clamp,
+  getQuantileIntervals,
+  calculateCenterOffset,
+  applyRotationTransform,
+  normalizeToPercentage,
+} from './math';
 import {
   getMessageVariables,
   replaceVariablesInMessage,
@@ -37,6 +45,9 @@ export {
   getContrastingTextColor,
   getMessageVariables,
   getQuantileIntervals,
+  calculateCenterOffset,
+  applyRotationTransform,
+  normalizeToPercentage,
   getUndefinedVariablesInMessage,
   parseBoolean,
   quantile,

--- a/src/math.ts
+++ b/src/math.ts
@@ -78,3 +78,80 @@ export const getQuantileIntervals = (data: number[], intervals: number[]) => {
     return _quantileForSorted(sorted, interval);
   });
 };
+
+/**
+ * Calculates the relative position of a point from the center of an element
+ *
+ * @param {number} mouseX - The x-coordinate of the mouse pointer
+ * @param {number} mouseY - The y-coordinate of the mouse pointer
+ * @param {DOMRect} rect - The bounding client rectangle of the target element
+ * @returns {{relativeX: number, relativeY: number}} Object containing x and y distances from center
+ */
+export const calculateCenterOffset = (
+  mouseX: number,
+  mouseY: number,
+  rect: DOMRect
+) => {
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+
+  return {
+    relativeX: mouseX - centerX,
+    relativeY: mouseY - centerY,
+  };
+};
+
+/**
+ * Applies a rotation matrix to coordinates
+ * Used to adjust mouse coordinates based on the current rotation of the image
+ * This function implements a standard 2D rotation matrix transformation:
+ * [x']   [cos(θ) -sin(θ)] [x]
+ * [y'] = [sin(θ)  cos(θ)] [y]
+ *
+ * @see {@link https://mathworld.wolfram.com/RotationMatrix.html} for mathematical derivation
+ *
+ * @param {number} relativeX - X-coordinate relative to center before rotation
+ * @param {number} relativeY - Y-coordinate relative to center before rotation
+ * @param {number} angle - Rotation angle in degrees
+ * @returns {{rotatedX: number, rotatedY: number}} Coordinates after applying rotation matrix
+ */
+export const applyRotationTransform = (
+  relativeX: number,
+  relativeY: number,
+  angle: number
+) => {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(-radians);
+  const sin = Math.sin(-radians);
+
+  return {
+    rotatedX: relativeX * cos - relativeY * sin,
+    rotatedY: relativeX * sin + relativeY * cos,
+  };
+};
+
+/**
+ * Converts absolute rotated coordinates to percentage values relative to image dimensions
+ * Ensures values are clamped between 0-100% for valid CSS transform-origin properties
+ *
+ * @param {number} rotatedX - X-coordinate after rotation transformation
+ * @param {number} rotatedY - Y-coordinate after rotation transformation
+ * @param {number} width - Width of the target element
+ * @param {number} height - Height of the target element
+ * @returns {{x: number, y: number}} Normalized coordinates as percentages (0-100%)
+ */
+export const normalizeToPercentage = (
+  rotatedX: number,
+  rotatedY: number,
+  width: number,
+  height: number
+) => {
+  // Convert to percentages (0-100%) relative to image dimensions
+  // 50% represents the center point
+  // The division by (width/2) maps the range [-width/2, width/2] to [-50%, 50%]
+  // Adding 50% shifts this to [0%, 100%]
+  return {
+    x: Math.max(0, Math.min(100, 50 + (rotatedX / (width / 2)) * 50)),
+    y: Math.max(0, Math.min(100, 50 + (rotatedY / (height / 2)) * 50)),
+  };
+};

--- a/test/math/viewport.test.ts
+++ b/test/math/viewport.test.ts
@@ -1,0 +1,168 @@
+import {
+  calculateCenterOffset,
+  applyRotationTransform,
+  normalizeToPercentage,
+} from '../../src';
+
+// Create a full DOMRect compatible mock
+const createRect = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): DOMRect => {
+  return {
+    x,
+    y,
+    width,
+    height,
+    left: x,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({
+      x,
+      y,
+      width,
+      height,
+      left: x,
+      top: y,
+      right: x + width,
+      bottom: y + height,
+    }),
+  } as DOMRect;
+};
+
+describe('calculateCenterOffset', () => {
+  it('should calculate correct offsets when mouse is at center', () => {
+    const mouseX = 150;
+    const mouseY = 100;
+    const rect = createRect(100, 50, 100, 100);
+    const expectedOutput = { relativeX: 0, relativeY: 0 };
+    const result = calculateCenterOffset(mouseX, mouseY, rect);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should calculate correct offsets when mouse is at top-left corner', () => {
+    const mouseX = 100;
+    const mouseY = 50;
+    const rect = createRect(100, 50, 100, 100);
+    const expectedOutput = { relativeX: -50, relativeY: -50 };
+    const result = calculateCenterOffset(mouseX, mouseY, rect);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should calculate correct offsets when mouse is at bottom-right corner', () => {
+    const mouseX = 200;
+    const mouseY = 150;
+    const rect = createRect(100, 50, 100, 100);
+    const expectedOutput = { relativeX: 50, relativeY: 50 };
+    const result = calculateCenterOffset(mouseX, mouseY, rect);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should calculate correct offsets when mouse is outside the element', () => {
+    const mouseX = 250;
+    const mouseY = 200;
+    const rect = createRect(100, 50, 100, 100);
+    const expectedOutput = { relativeX: 100, relativeY: 100 };
+    const result = calculateCenterOffset(mouseX, mouseY, rect);
+    expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe('applyRotationTransform', () => {
+  it('should not change coordinates when angle is 0 degrees', () => {
+    const relativeX = 50;
+    const relativeY = 25;
+    const angle = 0;
+    const expectedOutput = { rotatedX: 50, rotatedY: 25 };
+    const result = applyRotationTransform(relativeX, relativeY, angle);
+    expect(result.rotatedX).toBeCloseTo(expectedOutput.rotatedX);
+    expect(result.rotatedY).toBeCloseTo(expectedOutput.rotatedY);
+  });
+
+  it('should swap and negate coordinates when angle is 90 degrees', () => {
+    const relativeX = 50;
+    const relativeY = 25;
+    const angle = 90;
+    const expectedOutput = { rotatedX: 25, rotatedY: -50 };
+    const result = applyRotationTransform(relativeX, relativeY, angle);
+    expect(result.rotatedX).toBeCloseTo(expectedOutput.rotatedX);
+    expect(result.rotatedY).toBeCloseTo(expectedOutput.rotatedY);
+  });
+
+  it('should negate both coordinates when angle is 180 degrees', () => {
+    const relativeX = 50;
+    const relativeY = 25;
+    const angle = 180;
+    const expectedOutput = { rotatedX: -50, rotatedY: -25 };
+    const result = applyRotationTransform(relativeX, relativeY, angle);
+    expect(result.rotatedX).toBeCloseTo(expectedOutput.rotatedX);
+    expect(result.rotatedY).toBeCloseTo(expectedOutput.rotatedY);
+  });
+
+  it('should handle negative angles correctly', () => {
+    const relativeX = 50;
+    const relativeY = 25;
+    const angle = -90;
+    const expectedOutput = { rotatedX: -25, rotatedY: 50 };
+    const result = applyRotationTransform(relativeX, relativeY, angle);
+    expect(result.rotatedX).toBeCloseTo(expectedOutput.rotatedX);
+    expect(result.rotatedY).toBeCloseTo(expectedOutput.rotatedY);
+  });
+});
+
+describe('normalizeToPercentage', () => {
+  it('should convert center coordinates to 50%, 50%', () => {
+    const rotatedX = 0;
+    const rotatedY = 0;
+    const width = 100;
+    const height = 100;
+    const expectedOutput = { x: 50, y: 50 };
+    const result = normalizeToPercentage(rotatedX, rotatedY, width, height);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should convert extreme negative coordinates to 0%', () => {
+    const rotatedX = -100;
+    const rotatedY = -100;
+    const width = 100;
+    const height = 100;
+    const expectedOutput = { x: 0, y: 0 };
+    const result = normalizeToPercentage(rotatedX, rotatedY, width, height);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should convert extreme positive coordinates to 100%', () => {
+    const rotatedX = 100;
+    const rotatedY = 100;
+    const width = 100;
+    const height = 100;
+    const expectedOutput = { x: 100, y: 100 };
+    const result = normalizeToPercentage(rotatedX, rotatedY, width, height);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should correctly handle non-square dimensions', () => {
+    const rotatedX = 75;
+    const rotatedY = 50;
+    const width = 300;
+    const height = 200;
+    // For width 300: 50 + (75 / (300/2)) * 50 = 50 + (75 / 150) * 50 = 50 + 0.5 * 50 = 75
+    // For height 200: 50 + (50 / (200/2)) * 50 = 50 + (50 / 100) * 50 = 50 + 0.5 * 50 = 75
+    const expectedOutput = { x: 75, y: 75 };
+    const result = normalizeToPercentage(rotatedX, rotatedY, width, height);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should clamp values between 0% and 100%', () => {
+    const rotatedX = 1000;
+    const rotatedY = -1000;
+    const width = 100;
+    const height = 100;
+    const expectedOutput = { x: 100, y: 0 };
+    const result = normalizeToPercentage(rotatedX, rotatedY, width, height);
+    expect(result).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
# Image Zoom and Rotation Helpers

This PR adds three utility functions for handling image zoom and rotation based on cursor position. Ref: https://github.com/chatwoot/chatwoot/pull/11040

## Key Features:

1. `calculateCenterOffset`: Calculates the relative position of the cursor from the center of an image element. This helps establish the reference point for zooming operations.

2. `applyRotationTransform`: Applies a rotation matrix to coordinates, allowing adjustments to mouse coordinates based on the current rotation angle of the image. This ensures zoom operations work correctly even when the image is rotated.

3. `normalizeToPercentage`: Converts the calculated rotated coordinates to percentage values (0-100%) relative to the image dimensions. These values are used for CSS transform-origin properties.

## Use Cases:

- Double-click zooming that centers on the mouse cursor position
- Maintaining proper zoom origin point when the image is rotated
- Providing natural zoom behavior that follows the user's cursor
