### PR TITLE
feat: add split words method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 
 import { getRecipients } from './email';
 
-import { parseBoolean } from './string';
+import { parseBoolean, splitWords } from './string';
 import {
   sortAsc,
   quantile,
@@ -50,6 +50,7 @@ export {
   normalizeToPercentage,
   getUndefinedVariablesInMessage,
   parseBoolean,
+  splitWords,
   quantile,
   replaceVariablesInMessage,
   sortAsc,

--- a/src/string.ts
+++ b/src/string.ts
@@ -21,41 +21,44 @@ export function parseBoolean(candidate: string | number) {
  * Splits a string into an array of words, respecting quoted phrases.
  * Handles comma-separated values where phrases in double quotes are treated as a single unit,
  * even if they contain commas.
- * 
+ *
+ * This is basically CSV parsing, if we find this to be cumbersome to maintain,
+ * we can consider using a dedicated CSV parsing library.
+ *
  * Example: '"apple, banana", cherry' => ['apple, banana', 'cherry']
- * 
+ *
  * @param {string} candidate - The input string to split
  * @return {string[]} - Array of split words/phrases
  */
 export function splitWords(candidate: string): string[] {
   // Handle empty input case
   if (!candidate) return [''];
-  
+
   const result = [];
   let currentWord = '';
-  let inQuotes = false;  // Tracks whether we're currently inside a quoted section
-  
+  let inQuotes = false; // Tracks whether we're currently inside a quoted section
+
   // Process the string character by character
   for (let i = 0; i < candidate.length; i++) {
     const char = candidate[i];
-    
+
     // Toggle our "inside quotes" state when we encounter a quote character
     if (char === '"') {
       inQuotes = !inQuotes;
-      continue;  // Skip adding the quote character to the result
+      continue; // Skip adding the quote character to the result
     }
-    
+
     // Only treat commas as delimiters when not inside quotes
     if (char === ',' && !inQuotes) {
-      result.push(currentWord.trim());  // Add the completed word to results
-      currentWord = '';  // Reset for the next word
+      result.push(currentWord.trim()); // Add the completed word to results
+      currentWord = ''; // Reset for the next word
       continue;
     }
-    
+
     // For all other characters, add to the current word
     currentWord += char;
   }
-  
+
   // Check for mismatched quotes
   if (inQuotes) {
     throw new Error('Mismatched quotes in input string');
@@ -65,6 +68,6 @@ export function splitWords(candidate: string): string[] {
   if (currentWord.trim()) {
     result.push(currentWord.trim());
   }
-  
+
   return result;
 }

--- a/src/string.ts
+++ b/src/string.ts
@@ -16,3 +16,55 @@ export function parseBoolean(candidate: string | number) {
     return false;
   }
 }
+
+/**
+ * Splits a string into an array of words, respecting quoted phrases.
+ * Handles comma-separated values where phrases in double quotes are treated as a single unit,
+ * even if they contain commas.
+ * 
+ * Example: '"apple, banana", cherry' => ['apple, banana', 'cherry']
+ * 
+ * @param {string} candidate - The input string to split
+ * @return {string[]} - Array of split words/phrases
+ */
+export function splitWords(candidate: string): string[] {
+  // Handle empty input case
+  if (!candidate) return [''];
+  
+  const result = [];
+  let currentWord = '';
+  let inQuotes = false;  // Tracks whether we're currently inside a quoted section
+  
+  // Process the string character by character
+  for (let i = 0; i < candidate.length; i++) {
+    const char = candidate[i];
+    
+    // Toggle our "inside quotes" state when we encounter a quote character
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;  // Skip adding the quote character to the result
+    }
+    
+    // Only treat commas as delimiters when not inside quotes
+    if (char === ',' && !inQuotes) {
+      result.push(currentWord.trim());  // Add the completed word to results
+      currentWord = '';  // Reset for the next word
+      continue;
+    }
+    
+    // For all other characters, add to the current word
+    currentWord += char;
+  }
+  
+  // Check for mismatched quotes
+  if (inQuotes) {
+    throw new Error('Mismatched quotes in input string');
+  }
+
+  // Don't forget to add the last word if there is one
+  if (currentWord.trim()) {
+    result.push(currentWord.trim());
+  }
+  
+  return result;
+}

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -1,4 +1,4 @@
-import { parseBoolean } from '../src';
+import { parseBoolean, splitWords } from '../src';
 
 describe('#parseBoolean', () => {
   test('returns true for input "true"', () => {
@@ -35,5 +35,50 @@ describe('#parseBoolean', () => {
   test('returns false for input "undefined"', () => {
     // @ts-ignore
     expect(parseBoolean(undefined)).toBe(false);
+  });
+});
+
+describe('#splitWords', () => {
+  test('returns an array of words for input "apple,banana,cherry"', () => {
+    expect(splitWords('apple,banana,cherry')).toEqual([
+      'apple',
+      'banana',
+      'cherry',
+    ]);
+  });
+
+  test('returns an empty array for input ""', () => {
+    expect(splitWords('')).toEqual(['']);
+  });
+
+  test('returns an array with a single word for input "apple"', () => {
+    expect(splitWords('apple')).toEqual(['apple']);
+  });
+
+  test('allows phrases without double quotes', () => {
+    expect(splitWords('apple banana, cherry')).toEqual([
+      'apple banana',
+      'cherry',
+    ]);
+  });
+
+  test('allows phrases with double quotes', () => {
+    expect(splitWords('"apple banana", cherry')).toEqual([
+      'apple banana',
+      'cherry',
+    ]);
+  });
+
+  test('allows phrases with double quotes and commas', () => {
+    expect(splitWords('"apple, banana", cherry')).toEqual([
+      'apple, banana',
+      'cherry',
+    ]);
+  });
+
+  test('throws error for mismatched quotes', () => {
+    expect(() => splitWords('"apple, banana, cherry')).toThrow(
+      'Mismatched quotes in input string'
+    );
   });
 });


### PR DESCRIPTION
This PR adds a split words method that goes beyond the naive splitting using `string.split(',')` to a approach more akin to CSV parsing, that allows quoted blocks to be treated as their own candidate.

So `"apple, mango", orange` will be split as `['apple, mango', 'orange']`