### PR TITLE
feat: Add `isValidDomain` helper for validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   formatNumber,
 } from './helpers';
 
-import { toURL, isSameHost } from './url';
+import { toURL, isSameHost, isValidDomain } from './url';
 
 import { getRecipients } from './email';
 
@@ -62,6 +62,7 @@ export {
   splitName,
   toURL,
   isSameHost,
+  isValidDomain,
   trimContent,
   downloadFile,
   getFileInfo,

--- a/src/url.ts
+++ b/src/url.ts
@@ -50,3 +50,18 @@ export const isSameHost = (
     return false;
   }
 };
+
+/**
+ * Check if a string is a valid domain name.
+ * An empty string is allowed and considered valid.
+ *
+ * @param domain Domain to validate.
+ * @returns Whether the domain matches the rules.
+ */
+export const isValidDomain = (domain: string): boolean => {
+  if (domain === '') return true;
+
+  const domainRegex = /^(?!-)(?!.*--)[\p{L}0-9-]{1,63}(?<!-)(?:\.(?!-)(?!.*--)[\p{L}0-9-]{1,63}(?<!-))*\.[\p{L}]{2,63}$/u;
+
+  return domainRegex.test(domain) && domain.length <= 253;
+};

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,4 +1,4 @@
-import { toURL, isSameHost } from '../src';
+import { toURL, isSameHost, isValidDomain } from '../src';
 
 describe('toURL', () => {
   it('returns null for falsy inputs', () => {
@@ -78,5 +78,48 @@ describe('isSameHost', () => {
 
     expect(isSameHost(url1, url2)).toBe(true);
     expect(isSameHost(url1, url3)).toBe(false);
+  });
+});
+
+describe('#isValidDomain', () => {
+  it('should return true for valid domains', () => {
+    expect(isValidDomain('')).toBe(true);
+    expect(isValidDomain('google.com')).toBe(true);
+    expect(isValidDomain('example.org')).toBe(true);
+    expect(isValidDomain('test.net')).toBe(true);
+    expect(isValidDomain('www.google.com')).toBe(true);
+    expect(isValidDomain('api.example.org')).toBe(true);
+    expect(isValidDomain('deep.nested.subdomain.com')).toBe(true);
+    expect(isValidDomain('my-site.com')).toBe(true);
+    expect(isValidDomain('test-domain.co.uk')).toBe(true);
+    expect(isValidDomain('123domain.org')).toBe(true);
+    expect(isValidDomain('测试.网络')).toBe(true);
+    expect(isValidDomain('пример.рф')).toBe(true);
+    expect(isValidDomain('example.co.uk')).toBe(true);
+  });
+
+  it('should return false for invalid domains', () => {
+    const longDomain = 'a'.repeat(250) + '.com';
+    expect(isValidDomain('localhost')).toBe(false);
+    expect(isValidDomain('example.com!')).toBe(false);
+    expect(isValidDomain('test@domain.com')).toBe(false);
+    expect(isValidDomain('domain with spaces.com')).toBe(false);
+    expect(isValidDomain('test_domain.com')).toBe(false);
+    expect(isValidDomain('example..com')).toBe(false);
+    expect(isValidDomain('..example.com')).toBe(false);
+    expect(isValidDomain('example.com..')).toBe(false);
+    expect(isValidDomain('-example-.com')).toBe(false);
+    expect(isValidDomain(longDomain)).toBe(false);
+    expect(isValidDomain('192.168.1.1')).toBe(false);
+    expect(isValidDomain('127.0.0.1')).toBe(false);
+    expect(isValidDomain('example.com/path/to/page')).toBe(false);
+    expect(isValidDomain('http://example.com')).toBe(false);
+    expect(isValidDomain('https://example.com')).toBe(false);
+    expect(isValidDomain((null as unknown) as string)).toBe(false);
+    expect(isValidDomain((undefined as unknown) as string)).toBe(false);
+    expect(isValidDomain((123 as unknown) as string)).toBe(false);
+    expect(isValidDomain(({} as unknown) as string)).toBe(false);
+    expect(isValidDomain(([] as unknown) as string)).toBe(false);
+    expect(isValidDomain('   ')).toBe(false);
   });
 });


### PR DESCRIPTION
This PR adds a new helper `isValidDomain`

**Returns `true` for:**

* **Empty string** (treated as valid).
* **Standard domains**: `google.com`, `example.org`, `test.net`.
* **Subdomains (any depth)**: `www.google.com`, `api.example.org`, `deep.nested.subdomain.com`.
* **Hyphens in the middle**: `my-site.com`.
* **Multi-part TLDs**: `example.co.uk`, `test-domain.co.uk`.
* **Labels with digits**: `123domain.org`.
* **Internationalized (Unicode) domains**: `测试.网络`, `пример.рф`.
* **Length limit**: total domain length **≤ 253** chars; each label **1–63** chars.

**Returns `false` for:**

* **Single-label hosts**: `localhost`.
* **Invalid characters**: `example.com!`, `test@domain.com`, spaces, underscores, etc.
* **Dot misuse**: `example..com`, `..example.com`, `example.com..`.
* **Bad hyphen placement**: labels starting/ending with `-`, e.g., `-example-.com`.
* **Too long overall** (e.g., 250+`.com` pushing length >253).
* **IP addresses**: `192.168.1.1`, `127.0.0.1`.
* **URLs or paths**: `http://example.com`, `https://example.com`, `example.com/path`.
* **Non-strings / blanks**: `null`, `undefined`, numbers, objects, arrays, or just spaces.
* **Double hyphens anywhere** (disallowed by the regex), which also blocks punycode-style `xn--…` labels.
