### PR TITLE
chore: increase size-limit to 14 KB

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "size-limit": [
     {
       "path": "dist/utils.cjs.production.min.js",
-      "limit": "10 KB"
+      "limit": "14 KB"
     },
     {
       "path": "dist/utils.esm.js",
-      "limit": "10 KB"
+      "limit": "14 KB"
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
Bumps the size-limit budget for both bundle entries (`utils.cjs.production.min.js` and `utils.esm.js`) from 10 KB to 14 KB to accommodate upcoming additions to the package.