### PR TITLE
chore: bump version to 0.0.57

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/utils",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Chatwoot utils",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
Bumps `@chatwoot/utils` from `0.0.56` to `0.0.57` so the merged WhatsApp text-header parameter support can be published to npm.

Related: https://github.com/chatwoot/utils/pull/65

### Things to know

This PR changes only the version in `package.json`. After it merges, publish `@chatwoot/utils@0.0.57` and update Chatwoot to consume the new package version.